### PR TITLE
add missing _ResetVector, set correct vecbase

### DIFF
--- a/arch/xtensa/soc/LX6/linker.ld
+++ b/arch/xtensa/soc/LX6/linker.ld
@@ -42,13 +42,15 @@ PHDRS
   dram0_0_phdr PT_LOAD;
 }
 
-/*  Default entry point:  */
-PROVIDE ( _ResetVector = 0x40000400 );
-
 _rom_store_table = 0;
 
-PROVIDE(_memmap_vecbase_reset = 0x40000450);
-PROVIDE(_memmap_reset_vector = 0x40000400);
+/* TODO: set more strict CACHEATTR to catch access by bogus pointers */
+_memmap_cacheattr_wb_trapnull = 0x2222211F;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
+
+/* Vectors will be loaded into the start of IRAM. Set _memmap_vecbase_reset
+   accordingly so that startup code can adjust VECBASE */
+PROVIDE(_memmap_vecbase_reset = 0x40080000);
 
 SECTIONS
 {
@@ -111,6 +113,8 @@ SECTIONS
     . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
     . = 0x400;
+    KEEP(*(.ResetVector.text));
+    . = ALIGN(4);
     *(.*Vector.literal)
 
     *(.UserEnter.literal);


### PR DESCRIPTION
This change allows the application to be loaded and started as follows (in GDB):

```
mon reset halt
load
x $pc=_ResetVector
c
```

Note that the entry point in the ELF file still points to `__start` (because of a command line argument) but we need to do initialization which happens in _ResetVector.