### PR TITLE
Move .rodata into DRAM

### DIFF
--- a/arch/xtensa/soc/LX6/linker.ld
+++ b/arch/xtensa/soc/LX6/linker.ld
@@ -158,31 +158,6 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
-  /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-  {
-    . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN (8);
-    _bss_end = ABSOLUTE(.);
-    _heap_start = ABSOLUTE(.);
-    __stack = 0x4000000;
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
   SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(4))
   {
     _rodata_start = ABSOLUTE(.);
@@ -219,8 +194,35 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(ROMABLE_REGION)
+  } GROUP_LINK_IN(RAMABLE_REGION)
   /* >drom0_0_seg*/
+
+
+  /* Shared RAM */
+  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+    _heap_start = ABSOLUTE(.);
+    __stack = 0x4000000;
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
 
 #include <linker/common-ram.ld>
 #include <linker/common-rom.ld>


### PR DESCRIPTION
Currently .rodata is placed into IRAM, but IRAM doesn't support loads and stores other than 32-bit ones. This change moves .rodata into DRAM. Once the port progresses further and cache support is enabled, .rodata can be moved into DROM0 (i.e. stored into flash, accessible via cache).