### PR TITLE
xtensa: esp32: configure default UART using ROM functions

### DIFF
--- a/arch/xtensa/soc/LX6/linker.ld
+++ b/arch/xtensa/soc/LX6/linker.ld
@@ -25,6 +25,9 @@
 PROVIDE ( ets_get_cpu_frequency = 0x4000855c );
 PROVIDE ( uart_tx_one_char = 0x40009200 );
 PROVIDE ( uart_rx_one_char = 0x400092d0 );
+PROVIDE ( uartAttach = 0x40008fd0 );
+PROVIDE ( ets_install_uart_printf = 0x40007d28 );
+PROVIDE ( ets_printf = 0x40007d54 );
 
 MEMORY
 {

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -41,6 +41,9 @@ static int esp32_uart_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+    uartAttach();
+    ets_install_uart_printf();
+
 	return 0;
 }
 


### PR DESCRIPTION
ESP32 ROM functions can be used to output to UART once UART is configured. This change calls the right functions which configure the UART.

With this change, it is possible to use `ets_printf` to print to UART.

`printk` still doesn't work, probably because I can't find the right combinations of config options to enable it and without having to do `console_init`.